### PR TITLE
refactor: use Option.map to simplify match expressions

### DIFF
--- a/lib/board.ml
+++ b/lib/board.ml
@@ -359,11 +359,9 @@ let chess_mate (b : board) (c : color) =
           if line > 7 then None else aux line 0
         else aux line column
   in
-  let king_coord = aux 0 0 in
-  match king_coord with
-  | Some (line, column) ->
-      Some
-        (try attacked_coord_by_enemy b (line, column) c
+  aux 0 0
+  |> Option.map (fun (line, column) ->
+         try attacked_coord_by_enemy b (line, column) c
          with Invalid_coordinates -> (
            true
            &&
@@ -397,7 +395,6 @@ let chess_mate (b : board) (c : color) =
                          &&
                          try attacked_coord_by_enemy b (line + 1, column - 1) c
                          with Invalid_coordinates -> true)))))))))
-  | None -> None
 
 let need_promotion b current_player (coord_final_line, coord_final_column) =
   match get_piece b (coord_final_line, coord_final_column) with

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -343,10 +343,9 @@ let chess (b : board) (c : color) : bool option =
           if line > 7 then None else aux line 0
         else aux line column
   in
-  let king_coord = aux 0 0 in
-  match king_coord with
-  | Some (line, column) -> Some (attacked_coord_by_enemy b (line, column) c)
-  | None -> None
+  aux 0 0
+  |> Option.map (fun (line, column) ->
+         attacked_coord_by_enemy b (line, column) c)
 
 (*Check if player c has lost*)
 let chess_mate (b : board) (c : color) =

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -223,15 +223,15 @@ let move_from_coord_to_coord (b : board) (coord_start : coordinates)
   assert (is_valid_coordinates coord_start && is_valid_coordinates coord_final);
   let piece = get_piece b coord_start in
   let b = set_piece b coord_start None in
-  set_piece b coord_final
-    (match piece with
-    | None -> None
-    | Some piece -> (
-        match piece.shape with
-        | King _ -> Some { piece with shape = King false }
-        | Rook _ -> Some { piece with shape = Rook false }
-        | Pawn _ -> Some { piece with shape = Pawn false }
-        | _ -> Some piece))
+  Option.map
+    (fun piece ->
+      match piece.shape with
+      | King _ -> { piece with shape = King false }
+      | Rook _ -> { piece with shape = Rook false }
+      | Pawn _ -> { piece with shape = Pawn false }
+      | _ -> piece)
+    piece
+  |> set_piece b coord_final
 
 (*p is the piece we want to move*)
 let try_passant (b : board) (p : piece) (m : move) (next_player : player) =

--- a/lib/game_engine.ml
+++ b/lib/game_engine.ml
@@ -47,22 +47,16 @@ let play_move (g : game) (m : move) =
         | None -> false)
     | _ -> false
   in
-  match
-    Board.play_move g.board current_player m (get_next_player_from_game g)
-  with
-  | None -> None
-  | Some b ->
-      let g =
-        {
-          g with
-          board = b;
-          previous_position =
-            get_board_from_board g.board :: g.previous_position;
-        }
-      in
-      Some
-        (if fifty_rule then { g with fifty_moves = 0 }
-         else { g with fifty_moves = g.fifty_moves + 1 })
+  Board.play_move g.board current_player m (get_next_player_from_game g)
+  |> Option.map (fun b ->
+         let fifty_moves = if fifty_rule then 0 else g.fifty_moves + 1 in
+         {
+           g with
+           fifty_moves;
+           board = b;
+           previous_position =
+             get_board_from_board g.board :: g.previous_position;
+         })
 
 exception No_King
 


### PR DESCRIPTION
I saw two functions that could be simplified by using `Option.map`. 

For `play_move` I also simplified the `fifty_rule` update